### PR TITLE
Increase remix peer-dep range

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
   },
   "peerDependencies": {
-    "@remix-run/dev": "^1.5.1",
+    "@remix-run/dev": "^2.1.0",
     "eslint": ">=7"
   },
   "license": "ISC"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
   },
   "peerDependencies": {
-    "@remix-run/dev": "^2.1.0",
+    "@remix-run/dev": "^1.5.1 || ^2.0",
     "eslint": ">=7"
   },
   "license": "ISC"


### PR DESCRIPTION
I was having a peer dependency warning even though everything was working perfectly. I'm on `2.0.1` but thought `^2.1.0` would be good enough. Feel free to make any changes!